### PR TITLE
Adiciona CLI para escolher pipeline a executar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,4 +278,4 @@ aggregate-gazettes:  stop-aggregate-gazettes set-run-variable-values
 		--env PYTHONPATH=/mnt/code \
 		--env-file envvars \
 		--name agg-gazettes \
-		$(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) python tasks/gazette_txt_to_xml.py
+		$(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) python main -p aggregates

--- a/main/__main__.py
+++ b/main/__main__.py
@@ -1,4 +1,5 @@
 from os import environ
+import argparse
 import logging
 
 from data_extraction import create_apache_tika_text_extraction
@@ -6,6 +7,7 @@ from database import create_database_interface
 from storage import create_storage_interface
 from index import create_index_interface
 from tasks import (
+    create_aggregates,
     create_gazettes_index,
     create_themed_excerpts_index,
     embedding_rerank_excerpts,
@@ -35,9 +37,7 @@ def get_execution_mode():
     return environ.get("EXECUTION_MODE", "DAILY")
 
 
-def execute_pipeline():
-    enable_debug_if_necessary()
-
+def gazette_texts_pipeline():
     execution_mode = get_execution_mode()
     database = create_database_interface()
     storage = create_storage_interface()
@@ -61,5 +61,25 @@ def execute_pipeline():
         tag_entities_in_excerpts(theme, themed_excerpt_ids, index)
 
 
+def aggregates_pipeline():
+    database = create_database_interface()
+    storage = create_storage_interface()
+    create_aggregates(database, storage)
+
+
+def execute_pipeline(pipeline):
+    enable_debug_if_necessary()
+
+    if not pipeline or pipeline == "gazette_texts":
+        gazette_texts_pipeline()
+    elif pipeline == "aggregates":
+        aggregates_pipeline()
+    else:
+        raise ValueError("Pipeline inválido.")
+
+
 if __name__ == "__main__":
-    execute_pipeline()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--pipeline", help="Qual pipeline deve ser executado.")
+    args = parser.parse_args()
+    execute_pipeline(args.pipeline)

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -4,6 +4,7 @@ from .gazette_excerpts_entities_tagging import tag_entities_in_excerpts
 from .gazette_text_extraction import extract_text_from_gazettes
 from .gazette_themed_excerpts_extraction import extract_themed_excerpts_from_gazettes
 from .gazette_themes_listing import get_themes
+from .gazette_txt_to_xml import create_aggregates
 from .interfaces import (
     DatabaseInterface,
     StorageInterface,

--- a/tasks/gazette_txt_to_xml.py
+++ b/tasks/gazette_txt_to_xml.py
@@ -1,15 +1,15 @@
-from io import BytesIO
-from database import create_database_interface
-from storage import create_storage_interface
-import xml.etree.cElementTree as ET
 import traceback
+import xml.etree.cElementTree as ET
 from datetime import datetime
-from zipfile import ZipFile, ZIP_DEFLATED
-from utils.hash import hash_xml, hash_zip
+from io import BytesIO
 from xml.dom import minidom
+from zipfile import ZipFile, ZIP_DEFLATED
+
+from .utils import hash_xml, hash_zip
 
 
 need_update_zip_state = False
+
 
 def create_aggregates_table(database):
     database._commit_changes(
@@ -24,6 +24,7 @@ def create_aggregates_table(database):
             hash_info VARCHAR(64),
             file_size REAL
         ); """)
+
 
 def xml_content_generate(gazzetes_query_content:list, root, territory_id, storage):
     all_gazettes_tag = ET.SubElement(root, "diarios")
@@ -53,6 +54,7 @@ def xml_content_generate(gazzetes_query_content:list, root, territory_id, storag
         except:
             print(f"Erro na obtenção do conteúdo de texto do diário do territorio {territory_id}")
             continue
+
 
 def create_zip_for_state(xml_arr:list, year, state_code, database, storage):
     """
@@ -101,6 +103,7 @@ def create_zip_for_state(xml_arr:list, year, state_code, database, storage):
                 %(hash_info)s, %(file_size)s);", dict_query_info)
 
     zip_buffer.close()
+
 
 def create_zip_for_territory(xml_arr:list, database, storage):
     """
@@ -218,14 +221,11 @@ def create_aggregates_for_territories_and_states(territories_list:list, state, d
         
         xml_file.close()
 
-def create_aggregates():
+
+def create_aggregates(database, storage):
     """
     Create xml for all territories available in database
     """
-
-    database = create_database_interface()
-    storage = create_storage_interface()
-
     print("========== Script que agrega os arquivos .txt para .xml de territórios e estados ==========")
 
     results_query_states = database.select("SELECT DISTINCT state_code FROM territories ORDER BY state_code ASC;")
@@ -241,7 +241,3 @@ def create_aggregates():
         except:
             print(traceback.format_exc())
             continue
-
-
-if __name__ == "__main__":
-    create_aggregates()

--- a/tasks/utils/__init__.py
+++ b/tasks/utils/__init__.py
@@ -15,4 +15,5 @@ from .territories import (
 )
 from .hash import (
     hash_xml,
+    hash_zip,
 )

--- a/tasks/utils/index.py
+++ b/tasks/utils/index.py
@@ -1,6 +1,6 @@
 from typing import Dict, Iterable, List
 
-from tasks.interfaces import IndexInterface
+from ..interfaces import IndexInterface
 
 
 def get_documents_with_ids(


### PR DESCRIPTION
CLI permite que o pipeline principal seja executado sem argumento e também que a task de `create_aggregates` seja executada por meio do pipeline `aggregates`.